### PR TITLE
Standard Models

### DIFF
--- a/tawhiri/models.py
+++ b/tawhiri/models.py
@@ -30,7 +30,7 @@ _PI_180 = math.pi / 180.0
 _180_PI = 180.0 / math.pi
 
 
-## Up/down models #############################################################
+## Up/Down Models #############################################################
 
 
 def make_constant_ascent(ascent_rate):
@@ -71,7 +71,7 @@ def make_drag_descent(sea_level_descent_rate):
     return drag_descent
 
 
-## Sideways models ############################################################
+## Sideways Models ############################################################
 
 
 def make_wind_velocity(dataset):
@@ -150,10 +150,10 @@ def make_any_terminator(terminators):
     return terminator
 
 
-## Pre-defined combinations ###################################################
+## Pre-Defined Profiles #######################################################
 
 
-def standard_model(ascent_rate, burst_altitude, descent_rate, dataset):
+def standard_profile(ascent_rate, burst_altitude, descent_rate, dataset):
     """Make a model chain for the standard high altitude balloon situation of
        ascent at a constant rate followed by burst and subsequent descent
        at terminal velocity under parachute with a predetermined sea level
@@ -176,7 +176,7 @@ def standard_model(ascent_rate, burst_altitude, descent_rate, dataset):
     return ((model_up, term_up), (model_down, term_down))
 
 
-def float_model(ascent_rate, float_altitude, stop_time, dataset):
+def float_profile(ascent_rate, float_altitude, stop_time, dataset):
     """Make a model chain for the typical floating balloon situation of ascent
        at constant altitude to a float altitude which persists for some
        amount of time before stopping. Descent is in general not modelled.

--- a/testing/bench_prediction.py
+++ b/testing/bench_prediction.py
@@ -19,7 +19,7 @@ start_time = time.time()
 for i in range(n_repeats):
     ds = dataset.Dataset.open_latest(sys.argv[1])
     t0 = ds.ds_time + timedelta(hours=12)
-    stages = models.standard_model(5.0, 30000, 5.0, ds)
+    stages = models.standard_profile(5.0, 30000, 5.0, ds)
     result = solver.solve(t0, lat0, lng0, alt0, stages)
 end_time = time.time()
 

--- a/testing/test_prediction.py
+++ b/testing/test_prediction.py
@@ -19,7 +19,7 @@ n_repeats = 100
 
 ds = dataset.Dataset.open_latest(sys.argv[1])
 t0 = ds.ds_time + timedelta(hours=12)
-stages = models.standard_model(5.0, 30000, 5.0, ds)
+stages = models.standard_profile(5.0, 30000, 5.0, ds)
 result = solver.solve(t0, lat0, lng0, alt0, stages)
 
 with open("test_prediction_data.js", "w") as f:


### PR DESCRIPTION
Deals with #7. Looks like I'd already made the standard model. Renaming because we've used `make_` for things that return function closures and I feel like these final two functions `standard_model` and `float_model` are the main outputs for this module.

Added some comments to segment the file. Not sure how people feel about this. I definitely think having one models.py is nicer, as it's not a lot of code and mostly it's all used internally to compose these higher-level models so not really any point splitting it up. Comment segmentation is nice but perhaps a bit artificial.
