### PR TITLE
Set cython langugae_level=3

### DIFF
--- a/tawhiri/interpolate.pyx
+++ b/tawhiri/interpolate.pyx
@@ -17,6 +17,8 @@
 
 # Cython compiler directives:
 #
+# cython: language_level=3
+#
 # pick(...) is careful in what it returns:
 # cython: boundscheck=False
 # cython: wraparound=False

--- a/tawhiri/solver.pyx
+++ b/tawhiri/solver.pyx
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Tawhiri.  If not, see <http://www.gnu.org/licenses/>.
 
+# cython: language_level=3
+
 """
 Perform numerical integration of the balloon state.
 """


### PR DESCRIPTION
This (amongst some other things) switches to py3 syntax for `print`.
