### PR TITLE
setup.py: add dependency link for ruaumoko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ if PY2:
 else:
     entry_points = {}
 
+# Information on where to get non-PyPI packages
+dependency_links = [
+    'git+https://github.com/cuspaceflight/ruaumoko.git#egg=ruaumoko',
+]
+
 setup(
     name="Tawhiri",
     version=get_version(),
@@ -55,6 +60,7 @@ setup(
     description='High Altitude Balloon Landing Prediction Software',
     long_description=long_description,
     test_suite='nose.collector',
+    dependency_links=dependency_links,
     tests_require=['nose', 'mock'],
     install_requires=[
         "magicmemoryview",


### PR DESCRIPTION
Hello all,

At your lovely fresher's squash I asked @adamgreig if there was any projects he thought it would be worth pointing my eyes at since I'd like to get involved with CUSF this year. He suggested I look at the ol' predictor again and so here I am: :wave:.

I'll come along to the first meeting when it's announced on -team but since I have a spare afternoon to play with the predictor, I thought I'd try to get it up and running on my machine so I hope it's OK to throw some trivial build-related PRs at you.

As it stands, trying to git clone the repo and perform the standard `pip install -r requirements.txt` or `python setup.py develop` dance will fail unless you have ruaumoko[1] installed. If it is not installed, setuptools attempts to download it from PyPI which fails.

Add a `dependency_links` parameter to the call to `setup` which specifies where to fetch the code for ruaumoko.

[1] https://github.com/cuspaceflight/ruaumoko/
